### PR TITLE
GasMeter update, no producedEnergy.

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -2124,6 +2124,7 @@ export function gasMeter(args?: GasMeterArgs): ModernExtend {
         configureReporting: true,
         status: true,
         extendedStatus: true,
+        producedEnergy: false,
         ...args,
     };
     return genericMeter(args);


### PR DESCRIPTION
The simple gas meter can't produce energy so it is better to indicate this condition early